### PR TITLE
added gopath args for it

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,27 +17,24 @@ import (
 
 var cacheDir string
 var listen string
-var gopath string
+var goPath string
 var gpEnv string
 
 func init() {
 	flag.StringVar(&listen, "listen", "0.0.0.0:8081", "service listen address")
-	flag.StringVar(&gopath, "gopath", os.Getenv("GOPATH"), "default go path")
+	flag.StringVar(&goPath, "gopath", os.Getenv("GOPATH"), "default go path")
 	flag.Parse()
 }
 
 func main() {
 	// setup correct gopath
-	if gopath == "" {
+	if goPath == "" {
 		gpEnv := os.Getenv("GOPATH")
-		if gpEnv == "" {
-			panic("can not find $GOPATH")
-		}
 	} else {
-		if !filepath.IsAbs(gopath) {
-			gpEnv, _ = filepath.Abs(gopath)
+		if !filepath.IsAbs(goPath) {
+			gpEnv, _ = filepath.Abs(goPath)
 		} else {
-			gpEnv = gopath
+			gpEnv = goPath
 		}
 		os.Setenv("GOPATH", gpEnv)
 	}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func init() {
 func main() {
 	// setup correct gopath
 	if goPath == "" {
-		gpEnv := os.Getenv("GOPATH")
+		gpEnv = os.Getenv("GOPATH")
 	} else {
 		if !filepath.IsAbs(goPath) {
 			gpEnv, _ = filepath.Abs(goPath)


### PR DESCRIPTION
it is not able to set a dynamic gopath when using supervisor liked tools. for example:
````
[program:goproxy]
environment = HTTP_PROXY=http://127.0.0.1:7777,HTTPS_PROXY=http://127.0.0.1:7777 # can not set gopath dymicly in env
command = ./bin/goproxy -listen=0.0.0.0:9000 -gopath=./go_repo
stderr_logfile=/dev/stdout
stdout_logfile=/dev/stdout
````