### PR TITLE
Fixes Dockerfile build and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,23 @@
-FROM golang:1.11 AS build
+FROM golang:alpine AS build
 
-COPY ./ /goproxy
+RUN apk add --no-cache -U make
 
-RUN cd /goproxy &&\
-    export GO111MODULE=on &&\
-    go generate &&\
-    go mod tidy &&\
-    go build
+COPY . /src/goproxy
+WORKDIR /src/goproxy
 
-FROM alpine:3.8
-RUN apk add --no-cache git mercurial subversion bzr fossil
-COPY --from=build /goproxy/goproxy /bin/goproxy
+ENV CGO_ENABLED=0
+
+RUN make
+
+FROM alpine:latest
+
+RUN apk add --no-cache -U git mercurial subversion bzr fossil
+
+COPY --from=build /src/goproxy/goproxy /goproxy
+
+VOLUME /go
 
 EXPOSE 8081
 
-CMD ["goproxy"]
+ENTRYPOINT ["/goproxy"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: build generate image clean
+
+all: build
+
+build: generate
+	@go build -tags "netgo static_build" -installsuffix netgo -ldflags -w .
+
+generate:
+	@go generate
+
+image:
+	@docker build -t goproxy/goproxy .
+
+clean:
+	@git clean -f -d -X

--- a/build/generate.sh
+++ b/build/generate.sh
@@ -1,22 +1,22 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-PKG=${PWD}/internal
-GOROOT=`go env GOROOT`
+PKG="${PWD}/internal"
+GOROOT="$(go env GOROOT)"
 
-mkdir -p ${PKG}
-cp -r ${GOROOT}/src/cmd/go/internal/* ${PKG}
-
-
-cp -r ${GOROOT}/src/cmd/internal/browser ${PKG}
-cp -r ${GOROOT}/src/cmd/internal/buildid ${PKG}
-cp -r ${GOROOT}/src/cmd/internal/objabi ${PKG}
-cp -r ${GOROOT}/src/cmd/internal/test2json ${PKG}
-
-cp -r ${GOROOT}/src/internal/singleflight ${PKG}
-cp -r ${GOROOT}/src/internal/testenv ${PKG}
+mkdir -p "${PKG}"
+cp -r "${GOROOT}/src/cmd/go/internal/"* "${PKG}"
 
 
-find ${PKG} -type f -name '*.go' -exec sed -i 's/cmd\/go\/internal/github.com\/goproxyio\/goproxy\/internal/g' {} +
-find ${PKG} -type f -name '*.go' -exec sed -i 's/cmd\/internal/github.com\/goproxyio\/goproxy\/internal/g' {} +
-find ${PKG} -type f -name '*.go' -exec sed -i 's/internal\/singleflight/github.com\/goproxyio\/goproxy\/internal\/singleflight/g' {} +
-find ${PKG} -type f -name '*.go' -exec sed -i 's/internal\/testenv/github.com\/goproxyio\/goproxy\/internal\/testenv/g' {} +
+cp -r "${GOROOT}/src/cmd/internal/browser" "${PKG}"
+cp -r "${GOROOT}/src/cmd/internal/buildid" "${PKG}"
+cp -r "${GOROOT}/src/cmd/internal/objabi" "${PKG}"
+cp -r "${GOROOT}/src/cmd/internal/test2json" "${PKG}"
+
+cp -r "${GOROOT}/src/internal/singleflight" "${PKG}"
+cp -r "${GOROOT}/src/internal/testenv" "${PKG}"
+
+
+find "${PKG}" -type f -name '*.go' -exec sed -i -e 's/cmd\/go\/internal/github.com\/goproxyio\/goproxy\/internal/g' {} +
+find "${PKG}" -type f -name '*.go' -exec sed -i -e 's/cmd\/internal/github.com\/goproxyio\/goproxy\/internal/g' {} +
+find "${PKG}" -type f -name '*.go' -exec sed -i -e 's/internal\/singleflight/github.com\/goproxyio\/goproxy\/internal\/singleflight/g' {} +
+find "${PKG}" -type f -name '*.go' -exec sed -i -e 's/internal\/testenv/github.com\/goproxyio\/goproxy\/internal\/testenv/g' {} +

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:generate bash build/generate.sh
+//go:generate ./build/generate.sh
 
 package main
 


### PR DESCRIPTION
- Use POSIX `sh` instead of `bash` and fix all the bashisms.
- Add a `Makefile` for convenience
- Fix the `Dockerfile` to use `alpine` ffor building and runtime.

Fixes #42

Test Plan:

```#!bash
prologic@Jamess-MacBook
Thu Jan 10 15:13:02
~/Contributions/goproxy
 (master) 0
$ make image
Sending build context to Docker daemon  13.31MB
Step 1/13 : FROM golang:alpine AS build
 ---> f56365ec0638
Step 2/13 : RUN apk add -U git make build-base &&     rm -rf /var/cache/apk/*
 ---> Using cache
 ---> 773ed7e12b38
Step 3/13 : RUN go get -u golang.org/x/tools/cmd/stringer
 ---> Running in aaa6d43e4ee9
Removing intermediate container aaa6d43e4ee9
 ---> fe5729135362
Step 4/13 : COPY . /src/goproxy
 ---> 82c97ec12780
Step 5/13 : WORKDIR /src/goproxy
 ---> Running in 82fd40847e9b
Removing intermediate container 82fd40847e9b
 ---> 153ad4fac664
Step 6/13 : RUN make
 ---> Running in 9e5df14f14cc
Removing intermediate container 9e5df14f14cc
 ---> 16f64f0d40e2
Step 7/13 : FROM alpine:latest
 ---> 196d12cf6ab1
Step 8/13 : RUN apk add -U git mercurial subversion bzr fossil &&     rm -rf /var/cache/apk/*
 ---> Running in 0499900de123
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/28) Installing libbz2 (1.0.6-r6)
(2/28) Installing expat (2.2.5-r0)
(3/28) Installing libffi (3.2.1-r4)
(4/28) Installing gdbm (1.13-r1)
(5/28) Installing ncurses-terminfo-base (6.1_p20180818-r1)
(6/28) Installing ncurses-terminfo (6.1_p20180818-r1)
(7/28) Installing ncurses-libs (6.1_p20180818-r1)
(8/28) Installing readline (7.0.003-r0)
(9/28) Installing sqlite-libs (3.25.3-r0)
(10/28) Installing python2 (2.7.15-r1)
(11/28) Installing bzr (2.7.0-r1)
(12/28) Installing fossil (2.5-r1)
(13/28) Installing ca-certificates (20171114-r3)
(14/28) Installing nghttp2-libs (1.32.0-r0)
(15/28) Installing libssh2 (1.8.0-r3)
(16/28) Installing libcurl (7.61.1-r1)
(17/28) Installing pcre2 (10.31-r0)
(18/28) Installing git (2.18.1-r0)
(19/28) Installing mercurial (4.6.1-r0)
(20/28) Installing libuuid (2.32-r0)
(21/28) Installing apr (1.6.3-r1)
(22/28) Installing apr-util (1.6.1-r2)
(23/28) Installing db (5.3.28-r0)
(24/28) Installing lz4-libs (1.8.2-r0)
(25/28) Installing libsasl (2.1.26-r14)
(26/28) Installing serf (1.3.9-r4)
(27/28) Installing subversion-libs (1.10.0-r0)
(28/28) Installing subversion (1.10.0-r0)
Executing subversion-1.10.0-r0.pre-install
Executing busybox-1.28.4-r1.trigger
Executing ca-certificates-20171114-r3.trigger
OK: 120 MiB in 41 packages
Removing intermediate container 0499900de123
 ---> 21ef9d3249af
Step 9/13 : COPY --from=build /src/goproxy/goproxy /goproxy
 ---> a98cc1f5573e
Step 10/13 : VOLUME /go
 ---> Running in 79fe7f138234
Removing intermediate container 79fe7f138234
 ---> d8fdf5ff11ed
Step 11/13 : EXPOSE 8081
 ---> Running in 50e8012ea9cb
Removing intermediate container 50e8012ea9cb
 ---> e45b28e4409a
Step 12/13 : ENTRYPOINT ["/goproxy"]
 ---> Running in d616d3484210
Removing intermediate container d616d3484210
 ---> 63576ffedc3c
Step 13/13 : CMD []
 ---> Running in c3c623b1d353
Removing intermediate container c3c623b1d353
 ---> a40d7aaf9ffa
Successfully built a40d7aaf9ffa
Successfully tagged goproxyio/goproxy:latest

prologic@Jamess-MacBook
Thu Jan 10 15:14:16
~/Contributions/goproxy
 (master) 0
$ docker run -i -t -v goproxy:/go goproxyio/goproxy:latest
2019/01/10 05:14:37 goproxy: 2019-01-10 05:14:37 inited. listen on 0.0.0.0:8081
2019/01/10 05:14:37 goproxy: cache dir /go/pkg/mod/cache/download is not exist. To create it.
^C2019/01/10 05:15:00 goproxy: Server gracefully interrupt
```