### PR TITLE
Adds a contrib/goproxy.yml Stackfile for Docker Swarm deployment using Traefik

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,12 @@
+# contrib
+
+## goproxy.yml
+
+A Docker Swarm mode Stackfile configured for the [Traefik](https://traefik.io)
+ingress controller ready to deploy in your swarm cluster.
+
+Deploy with:
+
+```#!bash
+docker stack deploy -c goproxy.yml
+```

--- a/contrib/goproxy.yml
+++ b/contrib/goproxy.yml
@@ -1,0 +1,31 @@
+version: "3.4"
+
+services:
+  goproxy:
+    image: goproxy/goproxy
+    volumes:
+      - goproxy:/go
+    networks:
+      - bridge
+      - traefik
+    deploy:
+      placement:
+        constraints:
+          - "node.hostname == dm1.mydomain.com"
+      labels:
+        - "traefik.enable=true"
+        - "traefik.port=8081"
+        - "traefik.backend=goproxy"
+        - "traefik.docker.network=traefik"
+        - "traefik.frontend.rule=Host:goproxy.mydomain.com"
+      replicas: 1
+
+networks:
+  bridge:
+    external: true
+  traefik:
+    external: true
+
+volumes:
+  goproxy:
+    driver: local


### PR DESCRIPTION
Now that #43 is merged, this is a Docker Stackfile that you can use with
`docker stack` to deploy this as a service on any Docker Swarm mode cluster.

Modify to suit your environment -- especially your domain name.

Note that this uses and assumes the [Traefik](https://traefik.io) ingress
controller already deployed in your cluster.

I use a Stackfile //almost// exactly like this (//only domain is different//)

Enjoy :)