### PR TITLE
Modify docker-compose specified CMD for correct flag parsing.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
-version: "2"
+version: "2.4"
 services:
   goproxy:
     image: goproxy/goproxy:latest
-    command: "goproxy -listen=0.0.0.0:8081 -cacheDir=/ext"
+    command: "-listen=0.0.0.0:8081 -cacheDir=/ext"
     ports:
     - "8081:8081"
     restart: always


### PR DESCRIPTION
Quickfix for the docker-compose for #69 so actual CMD flags are respected.