### PR TITLE
add router mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,35 @@ A global proxy for go modules. see: [https://goproxy.io](https://goproxy.io)
     make
 
 ## Started
+
+
+### Proxy mode    
     
     ./bin/goproxy -listen=0.0.0.0:80 -cacheDir=/tmp/test
+
+### Router mode    
+
+Use the -proxy flag switch to "Router mode", which 
+implements route filter to routing private module 
+or public module .
+
+```
+                                         direct
+                      +----------------------------------> private repo
+                      |
+                 match|pattern
+                      |
+                  +---+---+           +----------+
+go get  +-------> |goproxy| +-------> |goproxy.io| +---> golang.org/x/net
+                  +-------+           +----------+
+                 router mode           proxy mode
+```
+
+In Router mode, use the -exclude flag set pattern , direct to the repo which 
+match the module path, pattern are matched to the full path specified, not only 
+to the host component.
+
+    ./bin/goproxy -listen=0.0.0.0:80 -cacheDir=/tmp/test -proxy https://goproxy.io -exclude "git.private.domain/[abc]"
 
 ## Use docker image
 

--- a/proxy/router.go
+++ b/proxy/router.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"regexp"
+)
+
+// A RouterOps provides the proxy host and the external pattern
+type RouterOps struct {
+	Pattern string
+	Proxy   string
+}
+
+// A Router is the proxy HTTP server,
+// which implements Route Filter to
+// routing private module or public module .
+type Router struct {
+	srv   *Server
+	proxy *httputil.ReverseProxy
+	regex *regexp.Regexp
+}
+
+// NewRouter returns a new Router using the given operations.
+func NewRouter(srv *Server, ops *RouterOps) *Router {
+	rt := &Router{
+		srv: srv,
+	}
+	if ops != nil {
+		if remote, err := url.Parse(ops.Proxy); err == nil {
+			rt.proxy = httputil.NewSingleHostReverseProxy(remote)
+			rt.proxy.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+		}
+		if regex, err := regexp.Compile(ops.Pattern); err == nil {
+			rt.regex = regex
+		}
+	}
+	return rt
+}
+
+func (rt *Router) Direct(path string) bool {
+	if rt.regex == nil {
+		return true
+	}
+	return rt.regex.Match([]byte(path))
+}
+
+func (rt *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if rt.proxy != nil && rt.Direct(r.URL.Path) {
+		fmt.Fprintf(os.Stdout, "[direct] %s\n", r.URL)
+		rt.srv.ServeHTTP(w, r)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "[proxy] %s\n", r.URL)
+	rt.proxy.ServeHTTP(w, r)
+	return
+}


### PR DESCRIPTION
Some time we need pull the private module and the 'outside' module which is out of the GFW. 

Use the -proxy flag switch to "Router mode", which  implements route filter to routing private module or public module .

```
                                         direct
                      +----------------------------------> private repo
                      |
                 match|pattern
                      |
                  +---+---+           +----------+
go get  +-------> |goproxy| +-------> |goproxy.io| +---> golang.org/x/net
                  +-------+           +----------+
                 router mode           proxy mode
```

In Router mode, use the -exclude flag set the pattern , the repo which match the module path will be direct, pattern are matched to the full path specified, not only to the host component.


