### PR TITLE
remove duplicate "goproxy" in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2"
 services:
   goproxy:
     image: goproxy/goproxy:latest
-    command: "goproxy -listen=0.0.0.0:8081 -cacheDir=/ext"
+    command: "-listen=0.0.0.0:8081 -cacheDir=/ext"
     ports:
     - "8081:8081"
     restart: always


### PR DESCRIPTION
with the duplicate 'goproxy' in docker-compose.yaml,  docker-compose up -d will invoke 'goproxy goproxy -listen=0.0.0.0:8081 -cacheDir=/ext' instead of 'goproxy -listen=0.0.0.0:8081 -cacheDir=/ext', thus, -listen and -cacheDir will not take effect.