### PR TITLE
Answer faster in case of non-supported checksum database

### DIFF
--- a/sumdb/handler.go
+++ b/sumdb/handler.go
@@ -35,12 +35,17 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, supported := range supportedSumDB {
-		uri := fmt.Sprintf("/sumdb/%s/supported", supported)
-		if r.URL.Path == uri {
-			w.WriteHeader(http.StatusOK)
-			return
+	if strings.HasSuffix(r.URL.Path, "/supported") {
+		for _, supported := range supportedSumDB {
+			uri := fmt.Sprintf("/sumdb/%s/supported", supported)
+			if r.URL.Path == uri {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
 		}
+
+		w.WriteHeader(http.StatusGone)
+		return
 	}
 
 	p := "https://" + strings.TrimPrefix(r.URL.Path, "/sumdb/")


### PR DESCRIPTION
Just a nit, PTAL if it makes sense.

I've tested by local:
Before: 
```
# curl -w %{http_code} http://0.0.0.0:8081/sumdb/sum.golang.org/supported
200
# curl -w %{http_code} http://0.0.0.0:8081/sumdb/gosum.io/supported
200
# curl -w %{http_code} http://0.0.0.0:8081/sumdb/goproxy.cn/supported
not found404
```

After:
```
# curl -w %{http_code} http://0.0.0.0:8081/sumdb/sum.golang.org/supported
200
# curl -w %{http_code} http://0.0.0.0:8081/sumdb/gosum.io/supported
200
# curl -w %{http_code} http://0.0.0.0:8081/sumdb/goproxy.cn/supported
410
```
cc @oiooj 