### PR TITLE
add tini for handling zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS build
 
-RUN apk add --no-cache -U make git mercurial subversion bzr fossil
+RUN apk add --no-cache -U make git mercurial subversion
 
 COPY . /src/goproxy
 RUN cd /src/goproxy &&\
@@ -9,7 +9,12 @@ RUN cd /src/goproxy &&\
 
 FROM golang:alpine
 
-RUN apk add --no-cache -U git mercurial subversion bzr fossil
+# Add tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64 /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+
+RUN apk add --no-cache -U git mercurial subversion
 
 COPY --from=build /src/goproxy/bin/goproxy /goproxy
 
@@ -17,5 +22,5 @@ VOLUME /go
 
 EXPOSE 8081
 
-ENTRYPOINT ["/goproxy"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/goproxy"]
 CMD []


### PR DESCRIPTION
Relates to issue #162.

Adds `tini` as a tiny init to handle reaping zombie processes., first advantage listed on the tini repo is:

> It protects you from software that accidentally creates zombie processes, which can (over time!) starve your entire system for PIDs (and make it unusable).

Also bzr and fossil are deprecated in the upstream alpine.
- [bzr](https://github.com/alpinelinux/docker-alpine/issues/87) due to python2 dependency
- [fossil](https://github.com/alpinelinux/aports/commit/d052af007210fc3e28105249970f9550e417084e) because it's unmaintained and the tests are failing.